### PR TITLE
Fix session save before redirect

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -112,7 +112,15 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
         }
       }
 
-      this.redirect(client.authorizationUrl(params));
+
+      if(req.session.save && typeof req.session.save == 'function') {
+        req.session.save(() => {
+          this.redirect(client.authorizationUrl(params));
+        });
+      } else {
+        this.redirect(client.authorizationUrl(params));
+      }
+
       return;
     }
     /* end authentication request */


### PR DESCRIPTION
This adds the session save before redirecting to Keycloak.
See: https://github.com/panva/node-openid-client/issues/146